### PR TITLE
Bump gemini-python-tutor v0.3.13 → v0.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ FROM ghcr.io/kangwonlee/edu-base-raw:60dfc33
 
 USER root
 
-RUN git clone --depth=1 --branch v0.3.13 https://github.com/kangwonlee/gemini-python-tutor /app/temp/ \
+RUN git clone --depth=1 --branch v0.4.1 https://github.com/kangwonlee/gemini-python-tutor /app/temp/ \
     && mkdir -p /app/ai_tutor/ \
     && mv /app/temp/*.py /app/ai_tutor \
+    && mv /app/temp/prompt_pipeline/ /app/ai_tutor/prompt_pipeline/ \
     && mv /app/temp/locale/ /app/ai_tutor/locale/
 
 RUN uv pip install --system --requirement /app/temp/requirements.txt \


### PR DESCRIPTION
## Summary

- Bump tutor tag from `v0.3.13` to `v0.4.1`
- Add `mv /app/temp/prompt_pipeline/ /app/ai_tutor/prompt_pipeline/` — the existing `*.py` glob only copied top-level files, silently skipping this subdirectory

## What's in v0.4.1

| PR | Change |
|----|--------|
| #36 | `llm_utils.py` — shared LLM utilities extracted from `entrypoint.py` |
| #33 | `prompt_pipeline/` — code generation for prompt-only assignments |
| #33 | `token_usage.json` — LLM token usage tracking output |

## Merge order

1. Tag `kangwonlee/gemini-python-tutor` HEAD as `v0.4.1`
2. Merge this PR
3. Cascade via upstream merge: template → template-custom → function-custom → 27 repos

## Validated by

- `cpf2503-20tue78/ai-tutor-ci` integration test harness detected the missing files ([run](https://github.com/cpf2503-20tue78/ai-tutor-ci/actions/runs/24301487769))
- `kangwonlee/python-integration-test#1` adds `llm_utils.py`, `prompt_pipeline/`, and `token_usage.json` checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)